### PR TITLE
Matchmaking: Sample from all possible matches

### DIFF
--- a/comprl/CHANGELOG.md
+++ b/comprl/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Instead, derive a custom class from it, that implements the `get_step` method.
 - BREAKING: Relative paths in the config file are now resolved relative to the
   config file location instead of to the working directory.
+- Matchmaking now samples from all candidates with quality above the threshold instead
+  of using the first in the list.
 
 ## Removed
 - The `Agent.event` decorator has been removed.  Instead of using it, create

--- a/comprl/pyproject.toml
+++ b/comprl/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comprl"
-version = "0.2.1-dev"
+version = "0.2.2-dev"
 description = "Competition Server for Reinforcement Agents -- Teamprojekt WS 23/24"
 authors = [
     {name = "Author Name", email = "optional@example.com"},

--- a/comprl/src/comprl/server/__main__.py
+++ b/comprl/src/comprl/server/__main__.py
@@ -131,8 +131,8 @@ class Server(IServer):
                 )
 
             plog("\nMatch quality scores:")
-            for u1, u2, score in self.matchmaking._match_quality_scores:
-                plog(f"\t{u1} vs {u2}: {score}")
+            for (u1, u2), score in self.matchmaking._match_quality_scores.items():
+                plog(f"\t{u1} vs {u2}: {score:0.4f}")
 
             plog("\nEND")
 

--- a/comprl/src/comprl/server/managers.py
+++ b/comprl/src/comprl/server/managers.py
@@ -461,7 +461,7 @@ class MatchmakingManager:
         rng = np.random.default_rng()
 
         i = 0
-        while i < len(self._queue):
+        while i < len(self._queue) - 1:
             player1 = self._queue[i]
             candidates = self._queue[i + 1 :]
 


### PR DESCRIPTION
Before this commit, the matchmaking was looping through the queue and matching a player with the first candidate where the match quality was above the threshold.
This commit change this so that match qualities are computed for all other candidates in the queue and then a match is found by sampling form all options above the threshold.

Use caching for the match quality score, so it is only computed once for each pair of user.  This is probably not really a concern performance-wise but has the benefit that only one entry is added to the monitoring data.