### PR TITLE
Fix game not being ended properly if saving game data fails

### DIFF
--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -19,9 +19,13 @@ def show_game(game: GameInfo) -> rx.Component:
         rx.table.cell(game.time),
         rx.table.cell(game.id),
         rx.table.cell(
-            rx.button(
-                "Download game data",
-                on_click=lambda: UserGamesState.download_game(game.id),
+            rx.cond(
+                game.has_game_file,
+                rx.button(
+                    "Download game data",
+                    on_click=lambda: UserGamesState.download_game(game.id),
+                ),
+                rx.text("No game data", align="center", style={"font-style": "italic"}),
             )
         ),
     )

--- a/comprl/src/comprl/server/interfaces.py
+++ b/comprl/src/comprl/server/interfaces.py
@@ -150,26 +150,27 @@ class IGame(abc.ABC):
         Args:
             reason (str): The reason why the game has ended. Defaults to "unknown".
         """
-        # store actions:
-        try:
-            # TODO: maybe add multithreading here to ease the load on the main server
-            # thread as storing the actions can take a while
-            self.game_info["actions"] = np.array(self.all_actions)
+        if self.disconnected_player_id is None:
+            # store actions:
+            try:
+                # TODO: maybe add multithreading here to ease the load on the main
+                # server thread as storing the actions can take a while
+                self.game_info["actions"] = np.array(self.all_actions)
 
-            data_dir = get_config().data_dir
-            # should already be checked during config loading but just to be sure
-            assert data_dir.is_dir(), f"data_dir '{data_dir}' is not a directory"
-            game_actions_dir = data_dir / "game_actions"
-            game_actions_dir.mkdir(exist_ok=True)
-            output_file = game_actions_dir / f"{self.id}.pkl"
+                data_dir = get_config().data_dir
+                # should already be checked during config loading but just to be sure
+                assert data_dir.is_dir(), f"data_dir '{data_dir}' is not a directory"
+                game_actions_dir = data_dir / "game_actions"
+                game_actions_dir.mkdir(exist_ok=True)
+                output_file = game_actions_dir / f"{self.id}.pkl"
 
-            logging.debug("Save game actions to %s", output_file)
-            with open(output_file, "wb") as f:
-                pickle.dump(self.game_info, f)
-        except Exception as e:
-            logging.error(
-                "Error while saving game actions: %s | game_id=%s", e, self.id
-            )
+                logging.debug("Save game actions to %s", output_file)
+                with open(output_file, "wb") as f:
+                    pickle.dump(self.game_info, f)
+            except Exception as e:
+                logging.error(
+                    "Error while saving game actions: %s | game_id=%s", e, self.id
+                )
 
         # notify end
         for callback in self.finish_callbacks:

--- a/comprl/src/comprl/server/interfaces.py
+++ b/comprl/src/comprl/server/interfaces.py
@@ -150,22 +150,26 @@ class IGame(abc.ABC):
         Args:
             reason (str): The reason why the game has ended. Defaults to "unknown".
         """
-
         # store actions:
-        # TODO: maybe add multithreading here to ease the load on the main server thread
-        # as storing the actions can take a while
-        self.game_info["actions"] = np.array(self.all_actions)
+        try:
+            # TODO: maybe add multithreading here to ease the load on the main server
+            # thread as storing the actions can take a while
+            self.game_info["actions"] = np.array(self.all_actions)
 
-        data_dir = get_config().data_dir
-        # should already be checked during config loading but just to be sure
-        assert data_dir.is_dir(), f"data_dir '{data_dir}' is not a directory"
-        game_actions_dir = data_dir / "game_actions"
-        game_actions_dir.mkdir(exist_ok=True)
-        output_file = game_actions_dir / f"{self.id}.pkl"
+            data_dir = get_config().data_dir
+            # should already be checked during config loading but just to be sure
+            assert data_dir.is_dir(), f"data_dir '{data_dir}' is not a directory"
+            game_actions_dir = data_dir / "game_actions"
+            game_actions_dir.mkdir(exist_ok=True)
+            output_file = game_actions_dir / f"{self.id}.pkl"
 
-        logging.debug("Save game actions to %s", output_file)
-        with open(output_file, "wb") as f:
-            pickle.dump(self.game_info, f)
+            logging.debug("Save game actions to %s", output_file)
+            with open(output_file, "wb") as f:
+                pickle.dump(self.game_info, f)
+        except Exception as e:
+            logging.error(
+                "Error while saving game actions: %s | game_id=%s", e, self.id
+            )
 
         # notify end
         for callback in self.finish_callbacks:


### PR DESCRIPTION
If a player disconnects during a game, it can happen that the game data is in a bad state which results in an error during saving.  In this case, the game wasn't cleaned up properly and the remaining player wasn't added back to the queue.

To generally avoid this in the future, catch errors during saving and simply log the error.
Futher, do not save at all if the game ends due to a player disconnect (since in this case the game is incomplete anyway).

Also a related change to the web interface: Only show download button if the game file actually exists.
