### PR TITLE
Add script to decay user scores over time and some refactoring

### DIFF
--- a/comprl/pyproject.toml
+++ b/comprl/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
 
 [project.scripts]
 comprl-users = "comprl.scripts.manage_users:app"
+comprl-games = "comprl.scripts.list_games:main"
+comprl-score-decay = "comprl.scripts.score_decay:main"
 
 [project.optional-dependencies]
 # Here you can specify optional dependencies (e.g. for tools that are only needed during

--- a/comprl/src/comprl/scripts/list_games.py
+++ b/comprl/src/comprl/scripts/list_games.py
@@ -9,12 +9,7 @@ import sys
 import sqlalchemy as sa
 import tabulate
 
-try:
-    import tomllib  # type: ignore[import-not-found]
-except ImportError:
-    # tomllib was added in Python 3.11.  Older versions can use tomli
-    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
-
+from comprl.server.config import load_config
 from comprl.server.data.sql_backend import Game
 from comprl.server.data.interfaces import GameEndState
 
@@ -36,11 +31,8 @@ def main() -> int:
         format="[%(asctime)s] [%(name)s | %(levelname)s] %(message)s",
     )
 
-    with open(args.config, "rb") as f:
-        data = tomllib.load(f)["CompetitionServer"]
-
-    db_path = data["database_path"]
-    engine = sa.create_engine(f"sqlite:///{db_path}")
+    config = load_config(args.config)
+    engine = sa.create_engine(f"sqlite:///{config.database_path}")
 
     fields = [
         "start_time",

--- a/comprl/src/comprl/scripts/manage_users.py
+++ b/comprl/src/comprl/scripts/manage_users.py
@@ -23,13 +23,20 @@ app = typer.Typer()
 @app.command()
 def list(
     database: Annotated[str, typer.Argument(help="Path to the database file.")],
+    ranked: Annotated[
+        bool, typer.Option("--ranked", help="Order user based on ranking.")
+    ],
 ) -> None:
     """List all users."""
     engine = sa.create_engine(f"sqlite:///{database}")
 
     data = []
     with sa.orm.Session(engine) as session:
-        users = session.scalars(sa.select(User)).all()
+        if ranked:
+            stmt = sa.select(User).order_by((User.mu - User.sigma).desc())
+        else:
+            stmt = sa.select(User)
+        users = session.scalars(stmt).all()
 
         for user in users:
             num_games_played = (

--- a/comprl/src/comprl/scripts/score_decay.py
+++ b/comprl/src/comprl/scripts/score_decay.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Slowly increase the sigma rating of users over time.
+
+Periodically increase the sigma rating of all users by a fixed amount.  This is to
+penalize users who have not played in a while.  Otherwise a user with a good start could
+just stop after few games and keep a good score, while other users might be better in
+the meantime.
+
+Increasing sigma of everyone by a fixed amount does not change the ranking (it might
+affect matchmaking, though?).  Only users who don't play anymore will slowly move down
+in the ranking.
+"""
+
+import argparse
+import contextlib
+import logging
+import sys
+import time
+
+import sqlalchemy as sa
+
+from comprl.server.config import load_config
+from comprl.server.data.sql_backend import User
+
+
+def adjust_scores(engine: sa.engine.Engine, amount: float) -> None:
+    """Adjust the scores of all users."""
+    with sa.orm.Session(engine) as session:
+        stmt = sa.update(User).values(sigma=User.sigma + amount)
+        session.execute(stmt)
+        session.commit()
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "config", type=str, help="Config file that specifies the database."
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        help="Interval (in minutes) at which scores are adjusted. Default: %(default)s",
+        default=15,
+    )
+    parser.add_argument(
+        "--amount",
+        type=float,
+        help="Amount added to sigma in each interval. Default: %(default)s",
+        default=0.5,
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="[%(asctime)s] [%(name)s | %(levelname)s] %(message)s",
+    )
+
+    config = load_config(args.config)
+    engine = sa.create_engine(f"sqlite:///{config.database_path}")
+
+    interval = args.interval * 60
+
+    while True:
+        time.sleep(interval)
+        logging.debug("Adjusting scores")
+        adjust_scores(engine, args.amount)
+
+    return 0
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        sys.exit(main())

--- a/comprl/src/comprl/server/config.py
+++ b/comprl/src/comprl/server/config.py
@@ -70,9 +70,12 @@ def set_config(config: Config):
 
 
 def load_config(
-    config_file: str | os.PathLike, dotlist_overwrites: list[str]
+    config_file: str | os.PathLike, dotlist_overwrites: list[str] | None = None
 ) -> Config:
     """Load config from config file and optional dotlist overwrites."""
+    if dotlist_overwrites is None:
+        dotlist_overwrites = []
+
     config_file = pathlib.Path(config_file)
 
     wconf = variconf.WConf(Config)


### PR DESCRIPTION
Add executable `comprl-score-decay` which periodically increases the sigma score of all users by a fixed amount.  This is to prevent users from keeping a good initial score by simply not playing anymore.

Some other minor changes, see commits.