### PR TITLE
Show client configuration in the user dashboard

### DIFF
--- a/comprl-hockey-game/config.toml
+++ b/comprl-hockey-game/config.toml
@@ -14,3 +14,4 @@ max_parallel_games = 100
 monitor_log_path = "/dev/shm/comprl_monitor"
 
 registration_key = "secret"
+server_url = "comprl.example.com"

--- a/comprl-web-reflex/comprl_web/pages/user_dashboard.py
+++ b/comprl-web-reflex/comprl_web/pages/user_dashboard.py
@@ -18,41 +18,56 @@ def dashboard() -> rx.Component:
     )
 
     return standard_layout(
-        rx.card(
-            rx.data_list.root(
-                rx.data_list.item(
-                    rx.data_list.label("username"),
-                    rx.data_list.value(LocalAuthState.authenticated_user.username),
-                ),
-                rx.data_list.item(
-                    rx.data_list.label("Access Token"),
-                    rx.data_list.value(LocalAuthState.authenticated_user.token),
-                ),
-                rx.data_list.item(
-                    rx.data_list.label("Ranking"),
-                    rx.data_list.value(f"{UserDashboardState.ranking_position}. place"),
-                ),
-                rx.data_list.item(
-                    rx.data_list.label("Games Played"),
-                    rx.data_list.value(
-                        UserDashboardState.game_statistics.num_games_played
+        rx.hstack(
+            rx.card(
+                rx.heading("User Information", style={"margin-bottom": "1rem"}),
+                rx.data_list.root(
+                    rx.data_list.item(
+                        rx.data_list.label("username"),
+                        rx.data_list.value(LocalAuthState.authenticated_user.username),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Access Token"),
+                        rx.data_list.value(LocalAuthState.authenticated_user.token),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Ranking"),
+                        rx.data_list.value(
+                            f"{UserDashboardState.ranking_position}. place"
+                        ),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Games Played"),
+                        rx.data_list.value(
+                            UserDashboardState.game_statistics.num_games_played
+                        ),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Games Won"),
+                        rx.data_list.value(
+                            UserDashboardState.game_statistics.num_games_won
+                        ),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Win rate"),
+                        rx.data_list.value(f"{win_rate} %"),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Disconnects"),
+                        rx.data_list.value(
+                            UserDashboardState.game_statistics.num_disconnects
+                        ),
                     ),
                 ),
-                rx.data_list.item(
-                    rx.data_list.label("Games Won"),
-                    rx.data_list.value(
-                        UserDashboardState.game_statistics.num_games_won
-                    ),
-                ),
-                rx.data_list.item(
-                    rx.data_list.label("Win rate"),
-                    rx.data_list.value(f"{win_rate} %"),
-                ),
-                rx.data_list.item(
-                    rx.data_list.label("Disconnects"),
-                    rx.data_list.value(
-                        UserDashboardState.game_statistics.num_disconnects
-                    ),
+            ),
+            rx.card(
+                rx.heading("Client Configuration", style={"margin-bottom": "1rem"}),
+                rx.spacer(),
+                rx.code_block(UserDashboardState.client_config, language="bash"),
+                rx.text("The client code can be found here: "),
+                rx.link(
+                    "GitHub: martius-lab/comprl-hockey-agent",
+                    href="https://github.com/martius-lab/comprl-hockey-agent",
                 ),
             ),
         ),

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -1,6 +1,7 @@
 """State for the protected pages."""
 
 import dataclasses
+import textwrap
 import pathlib
 from typing import Sequence
 
@@ -110,6 +111,17 @@ class UserDashboardState(ProtectedState):
         if rank is None:
             return -1
         return rank[0]
+
+    @rx.var(cache=True)
+    def client_config(self) -> str:
+        cfg = config.get_config()
+        return textwrap.dedent(
+            f"""
+            export COMPRL_SERVER_URL={cfg.server_url}
+            export COMPRL_SERVER_PORT={cfg.port}
+            export COMPRL_ACCESS_TOKEN={self.authenticated_user.token}
+            """
+        ).strip()
 
     @rx.event
     def update_ranked_users(self) -> None:

--- a/comprl/src/comprl/server/config.py
+++ b/comprl/src/comprl/server/config.py
@@ -50,6 +50,8 @@ class Config:
 
     #: Key that has to be specified to register
     registration_key: str = ""
+    #: URL of the competition server
+    server_url: str = "comprl.example.com"
 
 
 _config: Config | None = None


### PR DESCRIPTION
To make it easier for users to figure out how to configure their client, add a code block setting the environment variables to the corresponding values (so they can simply copy-paste that block). Also add a link to the GitHub repo with the example client code.

Add a new config value "server_url" for this, so we don't need to hard-code the server.