### PR TITLE
Show ranking score (mu - sigma) in leaderboard

### DIFF
--- a/comprl-web-reflex/comprl_web/pages/leaderboard.py
+++ b/comprl-web-reflex/comprl_web/pages/leaderboard.py
@@ -13,7 +13,7 @@ def leaderboard() -> rx.Component:
     return standard_layout(
         rx.data_table(
             data=UserDashboardState.leaderboard_entries,
-            columns=["Ranking", "Username", "µ / Σ"],
+            columns=["Ranking", "Username", "Score (µ - Σ)", "µ / Σ"],
             search=True,
             sort=False,
             pagination={"limit": 100},

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -128,9 +128,14 @@ class UserDashboardState(ProtectedState):
         self.ranked_users = self._get_ranked_users()  # type: ignore
 
     @rx.var(cache=True)
-    def leaderboard_entries(self) -> Sequence[tuple[int, str, str]]:
+    def leaderboard_entries(self) -> Sequence[tuple[int, str, float, str]]:
         return [
-            (i + 1, user.username, f"{user.mu:.2f} / {user.sigma:.2f}")
+            (
+                i + 1,
+                user.username,
+                round(user.mu - user.sigma, 2),
+                f"{user.mu:.2f} / {user.sigma:.2f}",
+            )
             for i, user in enumerate(self.ranked_users)
         ]
 


### PR DESCRIPTION
In addition to the mu / sigma column, add a column that shows the actual score used for the ranking (`mu - sigma`):

![image](https://github.com/user-attachments/assets/a225ea6b-5d4d-4092-a406-e7d1463925c0)
