### PR TITLE
Improve comprl monitor script

### DIFF
--- a/comprl/src/comprl/scripts/monitor.py
+++ b/comprl/src/comprl/scripts/monitor.py
@@ -140,7 +140,7 @@ class Parser:
         return False
 
     def _player_in_queue(self, line: str) -> bool:
-        m = re.match(r"\s+(\S+) \[(\S+)\] since (\S+)", line)
+        m = re.match(r"\s+(\S+) \[(\S+)\] since (.+)", line)
         if m:
             self.data["players_in_queue"].append(
                 {"player": m.group(1), "uuid": m.group(2), "timestamp": m.group(3)}

--- a/comprl/src/comprl/scripts/monitor.py
+++ b/comprl/src/comprl/scripts/monitor.py
@@ -202,11 +202,11 @@ class ComprlMonitorApp(App):
         """Compose the TUI layout."""
         yield Header()
         yield Label("Last Update:", id="timestamp", classes="h2")
-        yield Label("Connected Players:", classes="h2")
+        yield Label("Connected Players:", classes="h2", id="connected_players_label")
         yield DataTable(id="connected_players")
-        yield Label("Running Games:", classes="h2")
+        yield Label("Running Games:", classes="h2", id="games_label")
         yield DataTable(id="games")
-        yield Label("Players in Queue:", classes="h2")
+        yield Label("Players in Queue:", classes="h2", id="queue_label")
         yield DataTable(id="queue")
         yield Label("Match Quality Scores:", classes="h2")
         yield DataTable(id="match_quality_scores")
@@ -230,6 +230,10 @@ class ComprlMonitorApp(App):
         timestamp: Label = self.query_one("#timestamp")
         timestamp.update(f"Last Update: {parser.data['timestamp']}")
 
+        player_label: Label = self.query_one("#connected_players_label")
+        player_label.update(
+            f"Connected Players ({parser.data['num_connected_players']}):"
+        )
         player_table: DataTable = self.query_one("#connected_players")
         player_table.clear(columns=True)
         player_table.add_columns("User", "Player ID")
@@ -240,6 +244,8 @@ class ComprlMonitorApp(App):
             ]
         )
 
+        games_label: Label = self.query_one("#games_label")
+        games_label.update(f"Running Games ({parser.data['num_games']}):")
         games_table: DataTable = self.query_one("#games")
         games_table.clear(columns=True)
         games_table.add_columns("Game", "Player 1", "Player 2")
@@ -250,6 +256,10 @@ class ComprlMonitorApp(App):
             ]
         )
 
+        queue_label: Label = self.query_one("#queue_label")
+        queue_label.update(
+            f"Players in Queue ({parser.data['num_players_in_queue']}):"
+        )
         queue_table: DataTable = self.query_one("#queue")
         queue_table.clear(columns=True)
         queue_table.add_columns("User", "Player ID", "Timestamp")


### PR DESCRIPTION
- fix: Extract the whole timestamp for players in queue (not only the date)
- Show numbers of players/games in headers
- Add table showing players that are connected but neither in a game nor in the queue ("lost players").

Note on lost players:  There can be players which are connected but neither in a running game nor in the queue.  They are are likely only in some intermediate state at the start or end of a game but add them to the monitor view so we can keep an eye on this.  As long as players immediately disappear from that list again, all is fine but if a player is stuck there, it means there is a problem.