### PR TITLE
Change format of game data files and add more information

### DIFF
--- a/comprl-hockey-game/README.md
+++ b/comprl-hockey-game/README.md
@@ -42,6 +42,6 @@ There is also a script `select_top_player_games.py` to randomly select some game
 best users.  Together they may be used to generate videos of some top games:
 ```sh
 python select_top_player_games.py path/to/database.db > games.txt
-cat games.txt | parallel --csv python render_game.py path/to/game_actions/{3}.pkl --database path/to/database.db --save-video {1}_vs_{2}.mp4
+cat games.txt | parallel --csv python render_game.py path/to/game_actions/{3}.pkl --save-video {1}_vs_{2}.mp4
 ```
 (you may need to install `parallel` first)

--- a/comprl-hockey-game/hockey_game.py
+++ b/comprl-hockey-game/hockey_game.py
@@ -31,7 +31,6 @@ class HockeyGame(IGame):
             players (list[IPlayer]): list of players participating in this game.
                                       Handled by the abstract class
         """
-
         self.env = h_env.HockeyEnv()
         self.player_1_id = players[0].id
         self.player_2_id = players[1].id
@@ -48,12 +47,12 @@ class HockeyGame(IGame):
         # array storing all actions/observations/... of a round to be saved later.
         self.round_data = RoundData()
 
+        super().__init__(players)
+
         # add some useful metadata to the game log
         self.game_info["user_ids"] = [players[0].user_id, players[1].user_id]
         self.game_info["user_names"] = [players[0].username, players[1].username]
         self.game_info["rounds"] = []
-
-        super().__init__(players)
 
     def start(self):
         """
@@ -62,7 +61,7 @@ class HockeyGame(IGame):
         """
 
         self.obs_player_one, _ = self.env.reset()
-        self.observations_this_round.append(self.obs_player_one)
+        self.round_data.observations.append(self.obs_player_one)
         return super().start()
 
     def _end(self, reason="unknown"):

--- a/comprl/src/comprl/server/__main__.py
+++ b/comprl/src/comprl/server/__main__.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import os
 import pathlib
+import sys
 import time
 from typing import Type, TYPE_CHECKING
 
@@ -156,6 +157,7 @@ def load_class(module_path: str, class_name: str):
 
     # create the module
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
 
     # this is for mypy
     if not isinstance(spec.loader, importlib.abc.Loader):

--- a/comprl/src/comprl/server/interfaces.py
+++ b/comprl/src/comprl/server/interfaces.py
@@ -3,7 +3,7 @@ This module contains the interfaces for the non-networking logic.
 """
 
 import abc
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from datetime import datetime
 import numpy as np
 import pickle
@@ -118,7 +118,9 @@ class IGame(abc.ABC):
         self.disconnected_player_id: PlayerID | None = None
         # dict storing all actions and possible more to be saved later.
         # "actions" is a list of all actions in the game
-        self.game_info: dict[str, list[np.ndarray]] = {}
+        self.game_info: dict[str, Any] = {}
+        # TODO remove the all_actions here and leave the data logging completely to the
+        # game implementation?
         self.all_actions: list[np.ndarray] = []
         # When writing a game class you can fill the dict game_info with more
         # information

--- a/comprl/src/comprl/server/interfaces.py
+++ b/comprl/src/comprl/server/interfaces.py
@@ -1,11 +1,8 @@
-"""
-This module contains the interfaces for the non-networking logic.
-"""
+"""This module contains the interfaces for the non-networking logic."""
 
 import abc
 from typing import Any, Callable, Optional
 from datetime import datetime
-import numpy as np
 import pickle
 import logging
 
@@ -116,14 +113,10 @@ class IGame(abc.ABC):
         self.scores: dict[PlayerID, float] = {p.id: 0.0 for p in players}
         self.start_time = datetime.now()
         self.disconnected_player_id: PlayerID | None = None
-        # dict storing all actions and possible more to be saved later.
-        # "actions" is a list of all actions in the game
+
+        # dict for storing game data (e.g. actions, observations, ...).  It is up to the
+        # actual game implementation to file this dict with the relevant data.
         self.game_info: dict[str, Any] = {}
-        # TODO remove the all_actions here and leave the data logging completely to the
-        # game implementation?
-        self.all_actions: list[np.ndarray] = []
-        # When writing a game class you can fill the dict game_info with more
-        # information
 
     def add_finish_callback(self, callback: Callable[["IGame"], None]) -> None:
         """
@@ -157,7 +150,6 @@ class IGame(abc.ABC):
             try:
                 # TODO: maybe add multithreading here to ease the load on the main
                 # server thread as storing the actions can take a while
-                self.game_info["actions"] = np.array(self.all_actions)
 
                 data_dir = get_config().data_dir
                 # should already be checked during config loading but just to be sure
@@ -201,7 +193,6 @@ class IGame(abc.ABC):
                     # update the game, and if the game is over, end it
                     if self.disconnected_player_id is not None:
                         return
-                    self.all_actions.append([actions[p] for p in actions])
                     if not self._update(actions):
                         self._run()
                     else:


### PR DESCRIPTION
Add information about players, scores and rewards to the game data files and change the format in which they are stored.

The old format was a dictionary
```
{
  'actions_round_0': np.array(...),
  'observations_round_0': np.array(...),
  'actions_round_1': np.array(...),
  'observations_round_1': np.array(...),
  ...
  'num_rounds': np.array(...),
  'actions': np.array(...),
}
```

The new format is now
```
{
  'user_ids': (<id1>, <id2>),
  'user_names': (<name1>, <name2>),
  'rounds': [
    {
      'actions': np.array(...),
      'observations': np.array(...),
      'rewards': np.array(...),
      'score': (<score1>, <score2>),
    },
    ...
  ]
```


The script `render_game.py` is updated accordingly.  The options to swap players and to specify a database are removed (all relevant data is now in the game file itself).
Further, the video is made a bit nicer by showing the round numbers and the final result:

![example vide](https://github.com/user-attachments/assets/2d41b037-59a1-41df-843d-7b6d9946c44d)