### PR TITLE
Evaluation: Analyse matchmaking scores and other changes

### DIFF
--- a/comprl-hockey-game/Evaluation.ipynb
+++ b/comprl-hockey-game/Evaluation.ipynb
@@ -80,7 +80,14 @@
    "source": [
     "# get ranked users\n",
     "with sa.orm.Session(engine) as session:\n",
-    "    stmt = sa.select(User).order_by((User.mu - User.sigma).desc())\n",
+    "    # stmt = sa.select(User).order_by((User.mu - User.sigma).desc())\n",
+    "    # join with games table to exclude users who didn't play any games\n",
+    "    stmt = (\n",
+    "        sa.select(User)\n",
+    "        .join(Game, sa.or_(Game.user1 == User.user_id, Game.user2 == User.user_id))\n",
+    "        .group_by(User.user_id)\n",
+    "        .order_by((User.mu - User.sigma).desc())\n",
+    "    )\n",
     "    ranking = session.scalars(stmt).all()\n",
     "n_users = len(ranking)"
    ]
@@ -95,21 +102,6 @@
     "# get pairwise game statistics\n",
     "with sa.orm.Session(engine) as session:\n",
     "    user_pairwise_stats = get_user_pair_statistics(session, [user.user_id for user in ranking])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27e7eb6c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-03-16T12:10:14.231295Z",
-     "start_time": "2021-03-16T12:10:14.228003Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "lcb = np.asarray([user.mu - user.sigma for user in ranking])"
    ]
   },
   {
@@ -219,6 +211,42 @@
     ")\n",
     "ax.set_title('Win vs Lose - Rate')\n",
     "fig.savefig(\"Win-lose-matrix.png\", dpi=200, bbox_inches=\"tight\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f550505-7420-470f-8c42-f2d5776286f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# match quality comparision of top users\n",
+    "from openskill.models import PlackettLuce\n",
+    "skill_model = PlackettLuce()\n",
+    "match_qualities = np.zeros((n_users, n_users))\n",
+    "for i1, user1 in enumerate(ranking):\n",
+    "    rating1 = skill_model.create_rating([user1.mu, user1.sigma])\n",
+    "    for i2, user2 in enumerate(ranking):\n",
+    "        rating2 = skill_model.create_rating([user2.mu, user2.sigma])\n",
+    "        match_qualities[i1, i2] = skill_model.predict_draw([[rating1], [rating2]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1348b0e2-8e0f-485a-9622-83f0a322fb92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1,1, figsize=(8,7))\n",
+    "sns.heatmap(\n",
+    "    match_qualities,\n",
+    "    yticklabels=[user.username for user in ranking],\n",
+    "    xticklabels=[user.username for user in ranking],\n",
+    "    cmap='inferno',\n",
+    ")\n",
+    "ax.set_title('Match qualities')\n",
+    "#fig.savefig(\"match_qualities.png\", dpi=200, bbox_inches=\"tight\")"
    ]
   },
   {
@@ -345,7 +373,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f550505-7420-470f-8c42-f2d5776286f2",
+   "id": "84fe5769-5ba2-404c-8821-99a2de85e29a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# match quality comparision of top users\n",
+    "from openskill.models import PlackettLuce\n",
+    "skill_model = PlackettLuce()\n",
+    "match_qualities = np.zeros((n_users, n_users))\n",
+    "for i1, user1 in enumerate(ranking):\n",
+    "    rating1 = skill_model.create_rating([user1.mu, user1.sigma])\n",
+    "    for i2, user2 in enumerate(ranking):\n",
+    "        rating2 = skill_model.create_rating([user2.mu, user2.sigma])\n",
+    "        match_qualities[i1, i2] = skill_model.predict_draw([[rating1], [rating2]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eda5df1c-bbef-4aab-8896-188e8aef2bdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1,1, figsize=(8,7))\n",
+    "sns.heatmap(\n",
+    "    match_qualities,\n",
+    "    yticklabels=[user.username for user in ranking],\n",
+    "    xticklabels=[user.username for user in ranking],\n",
+    "    cmap='inferno',\n",
+    "    annot=True,\n",
+    "    fmt=\".2f\",\n",
+    "    square=True,\n",
+    ")\n",
+    "ax.set_title('Match qualities')\n",
+    "#fig.savefig(\"match_qualities_top10.png\", dpi=200, bbox_inches=\"tight\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e69d0ddf-9d35-486f-b318-ee5bbb654e4a",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
- Exclude users with zero games from the analysis.
- Remove unused cell for computing `lcb`.
- Create plot of match making scores for all users and a separate one
  for the top users only.
- Refactor `get_user_pair_statistics()` to use only one query instead of three (results in speed up by factor 3).