### PR TITLE
Bump Reflex version to 0.8.18

### DIFF
--- a/comprl-web-reflex/requirements.txt
+++ b/comprl-web-reflex/requirements.txt
@@ -1,3 +1,3 @@
-reflex==0.8.14.post1
+reflex==0.8.18
 passlib
 bcrypt


### PR DESCRIPTION
This fixes a security issue that was pointed out by Dependabot.