### PR TITLE
docker: Add "monitor" dependencies in image

### DIFF
--- a/comprl-hockey-game/Dockerfile
+++ b/comprl-hockey-game/Dockerfile
@@ -16,7 +16,7 @@ COPY ./comprl-hockey-game/requirements.txt .
 RUN apt-get update && apt-get install -y swig
 
 # Install comprl server
-RUN uv sync --locked
+RUN uv sync --locked --extra monitor
 RUN uv pip install -r ./requirements.txt
 
 


### PR DESCRIPTION
This allows to run `comprl-monitor` in the container.