### PR TITLE
Use `mu - 3*sigma` for ranking score

### DIFF
--- a/comprl-hockey-game/Evaluation.ipynb
+++ b/comprl-hockey-game/Evaluation.ipynb
@@ -82,13 +82,13 @@
    "source": [
     "# get ranked users\n",
     "with sa.orm.Session(engine) as session:\n",
-    "    # stmt = sa.select(User).order_by((User.mu - User.sigma).desc())\n",
+    "    # stmt = sa.select(User).order_by(User.ranking_order_expression().desc())\n",
     "    # join with games table to exclude users who didn't play any games\n",
     "    stmt = (\n",
     "        sa.select(User)\n",
     "        .join(Game, sa.or_(Game.user1 == User.user_id, Game.user2 == User.user_id))\n",
     "        .group_by(User.user_id)\n",
-    "        .order_by((User.mu - User.sigma).desc())\n",
+    "        .order_by(User.ranking_order_expression().desc())\n",
     "    )\n",
     "    ranking = session.scalars(stmt).all()\n",
     "n_users = len(ranking)"

--- a/comprl-hockey-game/select_top_player_games.py
+++ b/comprl-hockey-game/select_top_player_games.py
@@ -56,7 +56,11 @@ def main() -> int:
 
     # get ranked users
     with sa.orm.Session(engine) as session:
-        stmt = sa.select(User).order_by((User.mu - User.sigma).desc()).limit(args.n)
+        stmt = (
+            sa.select(User)
+            .order_by(User.ranking_order_expression().desc())
+            .limit(args.n)
+        )
         ranking = session.scalars(stmt).all()
 
     for user1, user2 in itertools.combinations(ranking, 2):

--- a/comprl-web-reflex/comprl_web/pages/leaderboard.py
+++ b/comprl-web-reflex/comprl_web/pages/leaderboard.py
@@ -12,7 +12,7 @@ def leaderboard() -> rx.Component:
     return standard_layout(
         rx.data_table(
             data=UserDashboardState.leaderboard_entries,
-            columns=["Ranking", "Username", "Score (µ - σ)", "µ / σ"],
+            columns=["Ranking", "Username", "Score (µ - 3σ)", "µ / σ"],
             search=True,
             sort=False,
             pagination={"limit": 100},

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -92,7 +92,7 @@ class UserDashboardState(ProtectedState):
             ranked_users_query = session.query(
                 User,
                 sa.func.rank()
-                .over(order_by=(User.mu - User.sigma).desc())
+                .over(order_by=User.ranking_order_expression().desc())
                 .label("rank"),
             ).subquery()
 
@@ -129,7 +129,7 @@ class UserDashboardState(ProtectedState):
             (
                 i + 1,
                 user.username,
-                round(user.mu - user.sigma, 2),
+                round(user.score(), 2),
                 f"{user.mu:.2f} / {user.sigma:.2f}",
             )
             for i, user in enumerate(self.ranked_users)

--- a/comprl/src/comprl/scripts/manage_users.py
+++ b/comprl/src/comprl/scripts/manage_users.py
@@ -33,7 +33,7 @@ def list(
     data = []
     with sa.orm.Session(engine) as session:
         if ranked:
-            stmt = sa.select(User).order_by((User.mu - User.sigma).desc())
+            stmt = sa.select(User).order_by(User.ranking_order_expression().desc())
         else:
             stmt = sa.select(User)
         users = session.scalars(stmt).all()
@@ -72,6 +72,7 @@ def list(
                     user.role,
                     user.mu,
                     user.sigma,
+                    user.score(),
                     num_games_played,
                     num_games_won,
                     num_disconnects,
@@ -87,6 +88,7 @@ def list(
                 "Role",
                 "Mu",
                 "Sigma",
+                "Score",
                 "Games Played",
                 "Games Won",
                 "Disconnects",

--- a/comprl/src/comprl/server/data/sql_backend.py
+++ b/comprl/src/comprl/server/data/sql_backend.py
@@ -38,6 +38,18 @@ class User(Base):
     mu: Mapped[float] = mapped_column(default=DEFAULT_MU)
     sigma: Mapped[float] = mapped_column(default=DEFAULT_SIGMA)
 
+    @staticmethod
+    def ranking_order_expression() -> sa.sql.expression.ColumnElement[float]:
+        """Get the expression used for ranking users.
+
+        This function can be used in order_by clauses.
+        """
+        return User.mu - 3 * User.sigma
+
+    def score(self) -> float:
+        """Compute the score of the user."""
+        return self.mu - 3 * self.sigma
+
 
 class Game(Base):
     """Games."""
@@ -114,7 +126,7 @@ class GameData:
 
 def get_ranked_users(session: sa.orm.Session) -> Sequence[User]:
     """Get all users ordered by their score (mu - sigma)."""
-    stmt = sa.select(User).order_by((User.mu - User.sigma).desc())
+    stmt = sa.select(User).order_by(User.ranking_order_expression().desc())
     return session.scalars(stmt).all()
 
 

--- a/docs/matchmaking.rst
+++ b/docs/matchmaking.rst
@@ -27,12 +27,7 @@ Each user has a score which consists of a values :math:`\mu` and :math:`\sigma`.
 skill value.  After each game, these values are updated based on the outcome of the game
 (won, lost, draw).
 
-For the leaderboard, the users are than ranked based on :math:`\mu - \sigma`.
-
-.. note::
-
-   The default in OpenSkill is actually :math:`\mu - 3\sigma`.  We should investigate,
-   if we want to use that as well.
+For the leaderboard, the users are than ranked based on :math:`\mu - 3\sigma`.
 
 
 Matchmaking


### PR DESCRIPTION
This is what Openskill (and I think also Trueskill) are using, so let's adopt it.
It has the nice side effect that new users start with a score of zero instead of some random number.

I also refactored a bit to not have that expression repeated everywhere. It is now only defined in two functions in the `User` class (one for the order-by expression, one for computing the actual score).  This will make it easier to change the expression if the future if needed.

I hope I got all places where `mu - sigma` was used.  At least by greping the source for "sigma", I didn't find any other occurrences.

Resolves #182.