### PR TITLE
Add Docker image for running bot agents

### DIFF
--- a/comprl-hockey-agent/run_client.py
+++ b/comprl-hockey-agent/run_client.py
@@ -72,6 +72,8 @@ def initialize_agent(agent_args: list[str]) -> Agent:
     )
     args = parser.parse_args(agent_args)
 
+    print(f"Run {args.agent} agent")
+
     # Initialize the agent based on the arguments.
     agent: Agent
     if args.agent == "weak":

--- a/comprl-hockey-game/Makefile
+++ b/comprl-hockey-game/Makefile
@@ -4,8 +4,14 @@
 build:
 	COMPOSE_BAKE=true docker compose build
 
-up:
-	docker compose up -d
+up-server:
+	docker compose up -d game-server
+
+up-bots:
+	docker compose up -d bot-agent-strong bot-agent-weak
+
+stop-bots:
+	docker compose stop bot-agent-strong bot-agent-weak
 
 down:
 	docker compose down

--- a/comprl-hockey-game/bot-agent.Dockerfile
+++ b/comprl-hockey-game/bot-agent.Dockerfile
@@ -1,0 +1,11 @@
+FROM comprl-hockey-game
+
+WORKDIR /agent
+
+# Add the code to run the bot clients
+COPY ./comprl-hockey-agent .
+
+USER comprl
+# add a sleep here so that when starting everything together, the server gets a
+# head-start before the bots are trying to connect.
+CMD sleep 5; python ./run_client.py --args --agent "${AGENT_TYPE}"

--- a/comprl-hockey-game/compose.yaml
+++ b/comprl-hockey-game/compose.yaml
@@ -1,6 +1,7 @@
 
 services:
   game-server:
+    image: comprl-hockey-game
     environment:
       COMPRL_CONFIG_PATH: ${COMPRL_CONFIG_PATH:-/config/config-docker.toml}
     build:
@@ -22,3 +23,34 @@ services:
         bind:
           create_host_path: true
     restart: always
+
+  # TODO: Is there a way to configure the two bot instances without duplicating
+  # everything?
+
+  bot-agent-strong:
+    image: comprl-hockey-bot
+    environment:
+      COMPRL_SERVER_URL: ${COMPRL_SERVER_URL:-game-server}
+      COMPRL_SERVER_PORT: ${COMPRL_SERVER_PORT:-65335}
+      COMPRL_ACCESS_TOKEN: ${STRONG_BOT_ACCESS_TOKEN}
+      AGENT_TYPE: ${AGENT_TYPE:-strong}
+    build:
+      context: ..
+      dockerfile: ./comprl-hockey-game/bot-agent.Dockerfile
+    restart: always
+    depends_on:
+      - game-server
+
+  bot-agent-weak:
+    image: comprl-hockey-bot
+    environment:
+      COMPRL_SERVER_URL: ${COMPRL_SERVER_URL:-game-server}
+      COMPRL_SERVER_PORT: ${COMPRL_SERVER_PORT:-65335}
+      COMPRL_ACCESS_TOKEN: ${WEAK_BOT_ACCESS_TOKEN}
+      AGENT_TYPE: ${AGENT_TYPE:-weak}
+    build:
+      context: ..
+      dockerfile: ./comprl-hockey-game/bot-agent.Dockerfile
+    restart: always
+    depends_on:
+      - game-server

--- a/docs/how_to_docker.rst
+++ b/docs/how_to_docker.rst
@@ -25,7 +25,7 @@ Some manual setup is needed to get things running:
 
    .. code:: sh
 
-      sudo make up
+      sudo make up-server
 
    in ``comprl-hockey-game``
 7. Start the web server by running
@@ -37,6 +37,31 @@ Some manual setup is needed to get things running:
    in ``comprl-web-reflex``
 
 Both can be stopped again by running ``sudo make down`` in both directories.
+
+
+Run Bots
+========
+
+Create two bot users and add their access tokens in the ``.env`` file:
+
+.. code:: sh
+
+    STRONG_BOT_ACCESS_TOKEN=token2
+    WEAK_BOT_ACCESS_TOKEN=token1
+
+Launch be bots with
+
+.. code:: sh
+
+   sudo make up-bots
+
+in ``comprl-hockey-game``.
+
+To stop only the bots but keep the server running, you can use
+
+.. code:: sh
+
+   sudo make stop-bots
 
 
 Reloading Configuration


### PR DESCRIPTION
Add services for weak and strong bot to the hockey game compose.yaml.  Adjust Makefile so server and bots can easily be started separately (just `docker compose up` would start them all at once).

Access tokens for the bot users need to be set in `.env`.  This is described in the documentation.