### PR TITLE
Docker: Only bind config file, use game file from container

### DIFF
--- a/comprl-hockey-game/Dockerfile
+++ b/comprl-hockey-game/Dockerfile
@@ -11,13 +11,13 @@ ENV UV_NO_DEV=1
 
 # Copy local context to `/app` inside container (see .dockerignore)
 COPY ./comprl .
-COPY ./comprl-hockey-game/requirements.txt .
+COPY ./comprl-hockey-game /hockey
 
 RUN apt-get update && apt-get install -y swig
 
 # Install comprl server
 RUN uv sync --locked --extra monitor
-RUN uv pip install -r ./requirements.txt
+RUN uv pip install -r /hockey/requirements.txt
 
 
 # =======================================
@@ -28,6 +28,7 @@ FROM python:3.13-slim
 WORKDIR /app
 RUN adduser --disabled-password --home /app comprl
 COPY --chown=comprl --from=init /app /app
+COPY --chown=comprl --from=init /hockey /hockey
 
 USER comprl
 ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1

--- a/comprl-hockey-game/compose.yaml
+++ b/comprl-hockey-game/compose.yaml
@@ -3,22 +3,23 @@ services:
   game-server:
     image: comprl-hockey-game
     environment:
-      COMPRL_CONFIG_PATH: ${COMPRL_CONFIG_PATH:-/config/config-docker.toml}
+      # this refers to the path inside the container (see binding added below)
+      COMPRL_CONFIG_PATH: /config.toml
     build:
       context: ..
       dockerfile: ./comprl-hockey-game/Dockerfile
     ports:
       - 65335:65335
     volumes:
-      #- upload-data:/app/uploaded_files
       # mount config files, so we can change config without rebuilding the container
       - type: bind
-        source: ./
-        target: /config
+        source: ${COMPRL_CONFIG_PATH:-./config-docker.toml}
+        target: /config.toml
+        read_only: true
         bind:
           create_host_path: false
       - type: bind
-        source: ${COMPRL_DATA_PATH:-/tmp/comprl-data}
+        source: ${COMPRL_DATA_PATH:-./}
         target: /comprl-data
         bind:
           create_host_path: true

--- a/comprl-hockey-game/config-docker.toml
+++ b/comprl-hockey-game/config-docker.toml
@@ -3,9 +3,9 @@ port = 65335
 server_update_interval = 5
 timeout = 10
 log_level = "INFO"
-game_path = "hockey_game.py"
+game_path = "/hockey/hockey_game.py"
 game_class = "HockeyGame"
-database_path = "hockey.db"
+database_path = "/comprl-data/hockey.db"
 data_dir = "/comprl-data"
 monitor_log_path = "/dev/shm/comprl_monitor"
 

--- a/comprl-web-reflex/compose.yaml
+++ b/comprl-web-reflex/compose.yaml
@@ -8,19 +8,19 @@
 services:
   app:
     environment:
-      COMPRL_CONFIG_PATH: ${COMPRL_CONFIG_PATH:-/config/config-docker.toml}
+      # this refers to the path inside the container (see binding added below)
+      COMPRL_CONFIG_PATH: /config.toml
     build:
       context: ..
       dockerfile: ./comprl-web-reflex/Dockerfile
     volumes:
-      # mount config files, so we can change config without rebuilding the container
       - type: bind
-        source: ../comprl-hockey-game
-        target: /config
+        source: ${COMPRL_CONFIG_PATH:-../comprl-hockey-game/config-docker.toml}
+        target: /config.toml
         bind:
           create_host_path: false
       - type: bind
-        source: ${COMPRL_DATA_PATH:-/tmp/comprl-data}
+        source: ${COMPRL_DATA_PATH:-../comprl-hockey-game}
         target: /comprl-data
         bind:
           create_host_path: true

--- a/docs/how_to_docker.rst
+++ b/docs/how_to_docker.rst
@@ -10,17 +10,28 @@ Further, the ``comprl-web-reflex`` folder contains Docker compose files for runn
 Some manual setup is needed to get things running:
 
 1. Clone the comprl repo
-2. Set ``o+w`` permissions for the ``comprl-hockey-game`` folder and the ``hockey.db`` file (TODO needs to be initialised first!)
+2. Create a data folder somewhere and set ``o+w`` permission.
+   Initialise the database file with name ``hockey.db`` in that folder (TODO: add
+   instructions for this)
 3. Create a file ``.env`` somewhere with the following content:
 
    .. code:: sh
 
-      COMPRL_DATA_PATH=/path/to/game/save/directory
+      COMPRL_DATA_PATH="<path to the data folder created in the previous step>"
       DOMAIN=your.server-domain.com
 
    Create symlinks to that file in both ``comprl-hockey-game`` and ``comprl-web-reflex``.
 4. Make sure the directory specified above exists and has ``o+w`` permissions.
 5. Adjust configuration to your needs in ``comprl-hockey-game/config-docker.toml``
+   (note that paths to database and data directory refer to inside the container and
+   should be kept at ``/comprl-data``).
+   You can also put the config file somewhere else and specify the path by adding
+   the following to the ``.env`` file:
+
+   .. code:: sh
+
+      COMPRL_CONFIG_PATH="/path/to/config.toml"
+
 6. Start the game server by running
 
    .. code:: sh


### PR DESCRIPTION
Instead of binding the whole config directory (including the game implementation) at run time, add it while building the image and then only bind the config file.  This means config can be changed without rebuilding the image but the game implementation is used from the container.

This means that
1. The database should be placed in the "data" directory
2. Paths in the config file need to be such that they match paths inside the container.