### PR TITLE
Enforce unique access tokens in the database.

### DIFF
--- a/comprl/src/comprl/server/data/sql_backend.py
+++ b/comprl/src/comprl/server/data/sql_backend.py
@@ -33,7 +33,7 @@ class User(Base):
     user_id: Mapped[int] = mapped_column(init=False, primary_key=True)
     username: Mapped[str] = mapped_column(unique=True)
     password: Mapped[bytes] = mapped_column()
-    token: Mapped[str] = mapped_column(sa.String(64))
+    token: Mapped[str] = mapped_column(sa.String(64), unique=True)
     role: Mapped[str] = mapped_column(default="user")
     mu: Mapped[float] = mapped_column(default=DEFAULT_MU)
     sigma: Mapped[float] = mapped_column(default=DEFAULT_SIGMA)


### PR DESCRIPTION
We are using UUIDs for the tokens, which in practice should never collide, but since it's trivial to enforce by simply making the db field unique, let's do that.
In the (very very VERY) unlikely case of two users with the same token, user creation should now fail with some error.  The error is no handled anywhere, so it might crash something but that's still better than the confusion that would arise from two players with the same token.

Closes #115.