### PR TITLE
doc: Restrict Sphinx version to <9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@
 # So when using this file locally, you also need to call it from the repo's root
 # directory.
 ./comprl
-sphinx
+sphinx<9
 sphinx-immaterial


### PR DESCRIPTION
With the latest Sphinx version (currently 9.0.4), the doc build fails with some TypeError in the Sphinx code.  I didn't find a solution so for the time being, simply restrict the version to the previous major release (8.x), which is working fine.